### PR TITLE
Bash syntax fix

### DIFF
--- a/plex-nvdec-patch.sh
+++ b/plex-nvdec-patch.sh
@@ -36,7 +36,7 @@ while (( "$#" )); do
       ;;
     -c|--codec)
       if contains ALLOWED_CODECS "$2"; then
-        CODECS+=$2
+        CODECS+=($2)
       else
         echo "ERROR: Incorrect codec $2, please refer to --help for allowed list" >&2
         exit 1

--- a/plex-nvdec-patch.sh
+++ b/plex-nvdec-patch.sh
@@ -76,7 +76,7 @@ else
     echo "ERROR: Plex Transcoder is currently running. Please stop any open transcodes and run again" >&2
     exit 1
   fi
-  mv /usr/lib/plexmediaserver/Plex\ Transcoder /usr/lib/plexmediaserver/Plex\ Transcoder2
+  mv "$PLEX_PATH/Plex Transcoder" "$PLEX_PATH/Plex Transcoder2"
 fi
 
 cstring="if [ "
@@ -85,7 +85,7 @@ for i in "${CODECS[@]}"; do
 done
 cstring+=']; then'
 
-cat > /usr/lib/plexmediaserver/Plex\ Transcoder <<< '#!/bin/bash
+cat > "$PLEX_PATH/Plex Transcoder" <<< '#!/bin/bash
 get_codec() {
     while [ "-i" != "$1" ]; do
       if [ "-codec:0" == "$1" ]; then
@@ -99,14 +99,14 @@ get_codec() {
 }
 
 codec="$(get_codec $*)"'
-cat >> /usr/lib/plexmediaserver/Plex\ Transcoder <<< "$cstring"
-cat >> /usr/lib/plexmediaserver/Plex\ Transcoder <<< '     exec /usr/lib/plexmediaserver/Plex\ Transcoder2 -hwaccel nvdec "$@"
+cat >> "$PLEX_PATH/Plex Transcoder" <<< "$cstring"
+cat >> "$PLEX_PATH/Plex Transcoder" <<< '     exec /usr/lib/plexmediaserver/Plex\ Transcoder2 -hwaccel nvdec "$@"
 else
      exec /usr/lib/plexmediaserver/Plex\ Transcoder2 "$@"
 fi
 
 ##patched'
 
-chmod +x /usr/lib/plexmediaserver/Plex\ Transcoder
+chmod +x "$PLEX_PATH/Plex Transcoder"
 
 echo "Patch applied successfully!"


### PR DESCRIPTION
After invoking the script as

    ./plex-nvdec-patch.sh -p /usr/lib/plexmediaserver -c h264 -c hevc -c mpeg2video -c vc1 -c vp9

Under Ubuntu Server 18.04, generated patch output is broken:

    if [ $codec == "h264hevcmpeg2videovc1vp9" ] || [ ]; then

Note that the syntax is wrong: https://stackoverflow.com/questions/1951506/add-a-new-element-to-an-array-without-specifying-the-index-in-bash

Attached is a simple patch which fixes this problem.

I've also included a fix so that the script will actually use the supplied custom path to Plex Transcoder.